### PR TITLE
[Unittest] Add SSD/Read test for not written case

### DIFF
--- a/SSDTest/test.cpp
+++ b/SSDTest/test.cpp
@@ -84,4 +84,19 @@ TEST_F(SSDTest, Write_test_boundary_check_fail) {
 	EXPECT_THAT(ssd_.read(100), Eq("0x00000000")) << "Check invalid scope";
 }
 
+TEST_F(SSDTest, Read_test_not_written_lba) {
+	{
+		InSequence seq;
+		EXPECT_CALL(m_nand_, write(20, "0x1289CDEF"))
+			.Times(1);
+		EXPECT_CALL(m_nand_, read(20))
+			.WillOnce(Return("0x1289CDEF"));
+		EXPECT_CALL(m_nand_, read(10))
+			.WillOnce(Return("0x00000000"));
+	}
+	ssd_.write(20, "0x1289CDEF");
+	EXPECT_THAT(ssd_.read(20), Eq("0x1289CDEF"));
+	EXPECT_THAT(ssd_.read(10), Eq("0x00000000"));
+}
+
 // TODO


### PR DESCRIPTION
안녕하세요.

> Read 명령어
> 한번도안적은곳은0x00000000 으로 읽힌다.

위 명세처럼 한 번도 Write를 실행하지 않은 LBA에 Read 시도 시, 0x00000000을 반환하는 테스트 케이스를 추가 하였습니다.

위 명세는 해당 LBA에 한 번도 Write를 하지 않음을 보여주는 것이 중요하다고 판단하여 InSequence를 사용하였습니다. 

리뷰 부탁 드립니다.