### PR TITLE
[Unittest] All Unit Test Case - Nand Initialize 0x00000000

### DIFF
--- a/SSDTest/nand_test.cpp
+++ b/SSDTest/nand_test.cpp
@@ -12,14 +12,13 @@ class SSDTestWithBabyStepNand : public testing::Test {
 protected:
 	void SetUp() override {
 		ssd_.selectNAND(&b_nand_);
+
+		for (int i = 0; i < 100; i++)
+			b_nand_.write(i, "0x00000000");
 	}
 public:
 	SSD ssd_;
 	BabyStepNand b_nand_;
-	void ResetNandforUnitTest() {
-		for (int i = 0; i < 100; i++)
-			b_nand_.write(i, "0x00000000");
-	}
 };
 
 TEST(NANDTest, Nand_single_write_read_test) {
@@ -29,15 +28,11 @@ TEST(NANDTest, Nand_single_write_read_test) {
 }
 
 TEST_F(SSDTestWithBabyStepNand, Write_lba_test_with_BabyStep) {
-	ResetNandforUnitTest();
-
 	ssd_.write(0x4, "0x00000003");
 	EXPECT_EQ("0x00000003",ssd_.read(0x4));
 }
 
 TEST_F(SSDTestWithBabyStepNand, Full_Read_test_with_BabyStep_Normal_Success) {
-	ResetNandforUnitTest();
-
 	const std::string input = "0xABCDEFAB";
 	for (int lba = 0; lba < 100; lba++) {
 		ssd_.write(lba, input);
@@ -51,8 +46,6 @@ TEST_F(SSDTestWithBabyStepNand, Full_Read_test_with_BabyStep_Normal_Success) {
 	
 
 TEST_F(SSDTestWithBabyStepNand, Full_Read_test_with_BabyStep_Normal_Fail) {
-	ResetNandforUnitTest();
-
 	const std::string input1 = "0xABCDEFAB";
 	for (int lba = 0; lba < 50; lba++) {
 		ssd_.write(lba, input1);
@@ -75,32 +68,22 @@ TEST_F(SSDTestWithBabyStepNand, Full_Read_test_with_BabyStep_Normal_Fail) {
 }
 
 TEST_F(SSDTestWithBabyStepNand, Write_lower_lba_fail_test) {
-	ResetNandforUnitTest();
-
 	EXPECT_THROW(ssd_.write(-1, "0x00000003"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, Write_upper_lba_fail_test) {
-	ResetNandforUnitTest();
-
 	EXPECT_THROW(ssd_.write(101, "0x00000003"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, Write_data_out_of_range_fail_test) {
-	ResetNandforUnitTest();
-
 	EXPECT_THROW(ssd_.write(3, "0x0000000003"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, Write_data_prefix_fail_test) {
-	ResetNandforUnitTest();
-
 	EXPECT_THROW(ssd_.write(3, "xx00000003"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, Write_Read_test_normal_success) {
-	ResetNandforUnitTest();
-
 	ssd_.write(0, "0xAAAABBBB");
 	EXPECT_EQ("0xAAAABBBB", ssd_.read(0));
 
@@ -109,8 +92,6 @@ TEST_F(SSDTestWithBabyStepNand, Write_Read_test_normal_success) {
 }
 
 TEST_F(SSDTestWithBabyStepNand, Write_Read_test_not_written_lba) {
-	ResetNandforUnitTest();
-
 	ssd_.write(0, "0xAAAABBBB");
 	EXPECT_EQ("0xAAAABBBB", ssd_.read(0));
 
@@ -119,8 +100,6 @@ TEST_F(SSDTestWithBabyStepNand, Write_Read_test_not_written_lba) {
 }
 
 TEST_F(SSDTestWithBabyStepNand, fullWrite_success_test_with_BabyStep) {
-	ResetNandforUnitTest();
-
 	for (int i = 0; i < 100; i++)
 		ssd_.write(i, "0xABCDFFFF");
 
@@ -129,36 +108,26 @@ TEST_F(SSDTestWithBabyStepNand, fullWrite_success_test_with_BabyStep) {
 }
 
 TEST_F(SSDTestWithBabyStepNand, fullWrite_fail_test_lba1_with_BabyStep) {
-	ResetNandforUnitTest();
-
 	for (int i = 0; i < 100; i++)
 		EXPECT_THROW(ssd_.write(i-100, "0xABCDFFFF"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, fullWrite_fail_test_lba2_with_BabyStep) {
-	ResetNandforUnitTest();
-
 	for (int i = 0; i < 100; i++)
 		EXPECT_THROW(ssd_.write(i + 100, "0xABCDFFFF"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, fullWrite_fail_test_value1_with_BabyStep) {
-	ResetNandforUnitTest();
-
 	for (int i = 0; i < 100; i++)
 		EXPECT_THROW(ssd_.write(i, "xxABCDFFFF"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, fullWrite_fail2_test_value2_with_BabyStep) {
-	ResetNandforUnitTest();
-
 	for (int i = 0; i < 100; i++)
 		EXPECT_THROW(ssd_.write(i, "0xABCDFFFFFF"), std::invalid_argument);
 }
 
 TEST_F(SSDTestWithBabyStepNand, fullWrite_twice_success_test_with_BabyStep) {
-	ResetNandforUnitTest();
-
 	for (int i = 0; i < 100; i++) {
 		ssd_.write(i, "0xABCDFFFF");
 		ssd_.write(i, "0x99999999");


### PR DESCRIPTION
모든 Unit Test 돌리기 전에 nand.txt 를 0x00000000으로 초기화.