### PR TITLE
[Refact] added ShellCmd class and apply command pattern for R/W commands

### DIFF
--- a/shell/Logger.cpp
+++ b/shell/Logger.cpp
@@ -103,7 +103,7 @@ void Logger::print(const std::string& functionName, const std::string& message) 
 		latestLogFile.flush();
 
 		// 10 KB = 10240 Bytes (in binary)
-		if (latestLogFile.tellp() > 10240) {
+		if (latestLogFile.tellp() > MAX_LATEST_SIZE) {
 			recordLog(currentTimeInfo);
 		}
 	}

--- a/shell/Logger.hpp
+++ b/shell/Logger.hpp
@@ -18,6 +18,7 @@ class Logger {
 private:
 	const std::string LOGGER_TIME_FORMAT = "[%y.%m.%d %H:%M:%S]";
 	const std::string LATEST_LOG_FILENAME = "latest.log"; // default file name: will be changed to date_time.log
+	const int MAX_LATEST_SIZE = 10240;
 
 	std::ofstream latestLogFile;
 

--- a/shell/ShellCmd.cpp
+++ b/shell/ShellCmd.cpp
@@ -153,6 +153,18 @@ public:
 	}
 };
 
+class ShellFlushCommand : public ShellCmd {
+private:
+public:
+	ShellFlushCommand() {
+	}
+
+	void execute() override {
+		LOG_FUNCTION_CALL("F");
+		system(makeSSDCommand("F", "", "").c_str());
+	}
+};
+
 // Invoker class
 class ShellCmdInvoker {
 private:

--- a/shell/ShellCmd.cpp
+++ b/shell/ShellCmd.cpp
@@ -1,0 +1,175 @@
+#pragma once
+#include <string>
+#include "Logger.hpp"
+
+#define APP_NAME "ssd "
+
+const int MAX_LBA = 99;
+const std::string RESULT_FILE_NAME = "result.txt";
+
+// Interface for ShellCmd
+class ShellCmd {
+public:
+	virtual ~ShellCmd() {}
+	virtual void execute() = 0;
+	virtual std::string getResult() { return ""; };
+protected:
+	std::string makeSSDCommand(std::string cmd, std::string arg1, std::string arg2) {
+		std::string result;
+		result = APP_NAME + cmd + " " + arg1 + " " + arg2;
+
+		return result;
+	}
+	std::string readFromResultFile(std::string fileName) {
+		std::ifstream inputFile(fileName);
+		std::string value;
+		if (!inputFile.is_open()) {
+			std::cout << "Failed to open file for reading." << std::endl;
+			return value;
+		}
+		std::getline(inputFile, value);
+		inputFile.close();
+		return value;
+	}
+private:
+
+};
+
+class ShellReadCommand : public ShellCmd {
+private:
+	std::string m_lba;
+	std::string result;
+public:
+	ShellReadCommand(std::istringstream& iss) {
+		iss >> m_lba;
+	}
+
+	void execute() override {
+		std::string str = makeSSDCommand("R", m_lba, "").c_str();
+		LOG_FUNCTION_CALL(str);
+		system(str.c_str());
+	}
+
+	std::string getResult() {
+		return result;
+	}
+};
+
+class ShellFullReadCommand : public ShellCmd {
+private:
+	bool m_compare;
+	std::string m_comp_val;
+	std::string result;
+public:
+	ShellFullReadCommand(bool compare, std::string comp_val)
+		: m_compare(compare), m_comp_val(comp_val)
+	{
+	}
+
+	void execute() override {
+		LOG_FUNCTION_CALL("");
+
+		for (int lba = 0; lba < (MAX_LBA + 1); lba++) {
+			system(makeSSDCommand("R", std::to_string(lba), "").c_str());
+
+			std::string read_val = readFromResultFile(RESULT_FILE_NAME);
+			std::cout << read_val << std::endl;
+
+			if (m_compare) {
+				if (read_val != m_comp_val) {
+					std::cout << "Read Compare Fail! in LBA: " << lba << std::endl;
+					std::cout << "Expected: " + m_comp_val + ", Result: " + read_val << lba << std::endl;
+					return;
+				}
+			}
+		}
+	}
+
+	std::string getResult() {
+		return result;
+	}
+};
+
+class ShellWriteCommand : public ShellCmd {
+private:
+	std::string m_lba;
+	std::string m_value;
+public:
+	ShellWriteCommand(std::istringstream& iss) {
+		iss >> m_lba;
+		iss >> m_value;
+	}
+
+	void execute() override {
+		std::string str = makeSSDCommand("W", m_lba, m_value).c_str();
+		LOG_FUNCTION_CALL(str);
+		system(str.c_str());
+	}
+};
+
+class ShellFullWriteCommand : public ShellCmd {
+private:
+	std::string m_value;
+public:
+	ShellFullWriteCommand(std::istringstream& iss) {
+		iss >> m_value;
+	}
+
+	void execute() override {
+		LOG_FUNCTION_CALL(m_value);
+		for (int i = 0; i < (MAX_LBA + 1); i++)
+			system(makeSSDCommand("W", std::to_string(i), m_value).c_str());
+	}
+};
+
+class ShellEraseCommand : public ShellCmd {
+private:
+	std::string m_lba;
+	std::string m_size;
+public:
+	ShellEraseCommand(std::istringstream& iss) {
+		iss >> m_lba;
+		iss >> m_size;
+	}
+
+	void execute() override {
+		system(makeSSDCommand("E", m_lba, m_size).c_str());
+	}
+};
+
+class ShellEraseRangeCommand : public ShellCmd {
+private:
+	std::string m_start_lba;
+	std::string m_end_lba;
+public:
+	ShellEraseRangeCommand(std::istringstream& iss) {
+		iss >> m_start_lba;
+		iss >> m_end_lba;
+	}
+
+	void execute() override {
+		int size = stoi(m_end_lba) - stoi(m_start_lba);
+		system(makeSSDCommand("E", m_start_lba, std::to_string(size)).c_str());
+	}
+};
+
+// Invoker class
+class ShellCmdInvoker {
+private:
+	ShellCmd* shell_command;
+public:
+	void setCommand(ShellCmd* cmd) {
+		shell_command = cmd;
+	}
+
+	void executeCommand() {
+		if (shell_command)
+			shell_command->execute();
+		else
+			std::cout << "ERR::NO_COMMAND_SET";
+	}
+
+	std::string getResult() {
+		return shell_command->getResult();
+	}
+};

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -362,6 +362,9 @@ int main(int argc, char* argv[]) {
 			else if (operation == "fullread") {
 				invoker.setCommand(new ShellFullReadCommand(false, ""));
 			}
+			else if (operation == "flush") {
+				invoker.setCommand(new ShellFlushCommand());
+			}
 			invoker.executeCommand();
 		}
 	}

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -8,14 +8,12 @@
 #include <cstdlib> // For system() function
 #include <io.h>
 #include "Logger.hpp"
-
-#define APP_NAME "ssd "
+#include "ShellCmd.cpp"
 
 const int MIN_LBA = 0;
-const int MAX_LBA = 99;
 const int VALUE_LENGTH = 10;
+
 const std::string PREFIX_VALUE = "0x";
-const std::string RESULT_FILE_NAME = "result.txt";
 const std::string RUNNER_RESULT_FILE_NAME = "testResult.txt";
 
 void checkLbaRange(int lba) {
@@ -183,9 +181,8 @@ void help() {
 	std::cout << "***********************************" << std::endl;
 	std::cout << std::endl;
 }
-bool exit() {
+void exit() {
 	std::cout << "Exiting the program..." << std::endl;
-	return false;
 }
 
 std::string makeSSDCommand(std::string cmd, std::string arg1, std::string arg2) {
@@ -195,63 +192,19 @@ std::string makeSSDCommand(std::string cmd, std::string arg1, std::string arg2) 
 	return result;
 }
 
-bool erase(std::string lba, std::string size) {
-	system(makeSSDCommand("E", lba, size).c_str());
-
-	return true;
-}
-
-bool erase_range(std::string startlba, std::string endlba) {
-	int size = stoi(endlba) - stoi(startlba);
-
-	erase(startlba, std::to_string(size));
-
-	return true;
-}
-
-bool write(std::string lba, std::string value) {
-	std::string str = makeSSDCommand("W", lba, value).c_str();
-	LOG_FUNCTION_CALL(str);
-	system(str.c_str());
-
-	return true;
-}
-bool read(std::string lba) {
-	std::string str = makeSSDCommand("R", lba, "").c_str();
-	LOG_FUNCTION_CALL(str);
-	system(str.c_str());
-
-	return true;
-}
-
-void fullWrite(std::string value) {
-	LOG_FUNCTION_CALL(value);
-	for (int i = 0; i < (MAX_LBA + 1); i++)
-		system(makeSSDCommand("W", std::to_string(i), value).c_str());
-}
-
-bool fullRead(bool compare, std::string comp_val) {
-	LOG_FUNCTION_CALL("");
-
-	for (int lba = 0; lba < (MAX_LBA + 1); lba++) {
-		system(makeSSDCommand("R", std::to_string(lba), "").c_str());
-
-		std::string read_val = readFromResultFile(RESULT_FILE_NAME);
-		std::cout << read_val << std::endl;
-
-		if (compare) {
-			if (read_val != comp_val)
-				return false;
-		}
-	}
-}
-
 bool testApp1() {
 	const std::string input = "0xABCDEFAB";
 	LOG_FUNCTION_CALL("Full Write: " + input + " + ReadCompare");
 
-	fullWrite(input);
-	return fullRead(true, input);
+	ShellCmdInvoker invoker;
+	std::istringstream iss(input);
+	invoker.setCommand(new ShellFullWriteCommand(iss));
+	invoker.executeCommand();
+
+	invoker.setCommand(new ShellFullReadCommand(true, input));
+	invoker.executeCommand();
+
+	return true;
 }
 
 bool testApp2() {
@@ -341,67 +294,69 @@ int main(int argc, char* argv[]) {
 
 	std::string command, operation, lba, endlba, value, size;
 
+	std::cout << "Welcome to ShellProgram!!" << std::endl;
 	while (true) {
-		std::cout << "Welcome to ShellProgram!!: "; // Updated prompt
-		std::getline(std::cin, command);
+		ShellCmdInvoker invoker;
+		std::cout << "Enter a command: "; std::getline(std::cin, command);
 
 		if (!(verifyCommandFormat(command)))
 			continue;
 
-		// parsing commands
+		// Parse operation in command
 		std::istringstream iss(command);
 		iss >> operation;
 
-		// Shell commands
-		if (operation == "exit") {
-			exit();
-			break;
+		// Shell general commands
+		{
+			if (operation == "exit") {
+				exit();
+				break;
+			}
+			else if (operation == "help") {
+				help();
+				continue;
+			}
 		}
 
-		if (operation == "help") {
-			help();
-			continue;
-		}
-
-		/*RW commands*/
-		if (operation == "erase") {
-			iss >> lba;
-			iss >> size;
-			erase(lba, size);
-		}
-		else if (operation == "erase_range") {
-			iss >> lba;
-			iss >> endlba;
-			erase_range(lba, endlba);
-		}
-		else if (operation == "write") {
-			iss >> lba;
-			iss >> value;
-			write(lba, value);
-		}
-		else if (operation == "read") {
-			iss >> lba;
-			read(lba);
-		}
-		else if (operation == "fullwrite") {
-			iss >> value;
-			fullWrite(value);
-		}
-		else if (operation == "fullread") {
-			fullRead(false, "");
-		}
 		/*TestApp commands*/
-		else if (operation == "testapp1") {
-			if (testApp1())
-				std::cout << "testapp1: Compare Success!" << std::endl;
-			else
-				std::cout << "testapp1: Compare Fail!" << std::endl;
+		{
+			if (operation == "testapp1") {
+				if (testApp1())
+					std::cout << "testapp1: Compare Success!" << std::endl;
+				else
+					std::cout << "testapp1: Compare Fail!" << std::endl;
+				continue;
+			}
+			else if (operation == "testapp2") {
+				if (testApp2())
+					std::cout << "testapp2: Compare Success!" << std::endl;
+				else
+					std::cout << "testapp2: Compare Fail!" << std::endl;
+				continue;
+			}
 		}
-		else if (operation == "testapp2") {
-			if (testApp2())
-				std::cout << "testapp2: Compare Success!" << std::endl;
-			else
-				std::cout << "testapp2: Compare Fail!" << std::endl;
+
+		/*R/W commands*/
+		{
+			if (operation == "erase") {
+				invoker.setCommand(new ShellEraseCommand(iss));
+			}
+			else if (operation == "erase_range") {
+				invoker.setCommand(new ShellEraseRangeCommand(iss));
+			}
+			else if (operation == "write") {
+				invoker.setCommand(new ShellWriteCommand(iss));
+			}
+			else if (operation == "read") {
+				invoker.setCommand(new ShellReadCommand(iss));
+			}
+			else if (operation == "fullwrite") {
+				invoker.setCommand(new ShellFullWriteCommand(iss));
+			}
+			else if (operation == "fullread") {
+				invoker.setCommand(new ShellFullReadCommand(false, ""));
+			}
+			invoker.executeCommand();
 		}
 	}
 }

--- a/shell/shell.vcxproj
+++ b/shell/shell.vcxproj
@@ -130,6 +130,7 @@
   <ItemGroup>
     <ClCompile Include="Logger.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="ShellCmd.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/shell/shell.vcxproj.filters
+++ b/shell/shell.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="ShellCmd.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
- ShellCmd 를 shell main에 추가하였습니다. + command pattern 적용
일단 R/W command 위주로만 발라냈습니다.

TODO
- Header 분리 작업
- testapp에 대한 command pattern 작업