### PR TITLE
[Fix] fix some zip compression in Logger and added internal command f…

### DIFF
--- a/shell/Logger.cpp
+++ b/shell/Logger.cpp
@@ -18,6 +18,7 @@ that manages the log output by the test shell
 
 Logger::Logger() {
 	openNewLogFile();
+	recordCount = 0;
 }
 
 /* 1. ctor, 2. end of recordLog*/
@@ -46,12 +47,13 @@ void Logger::recordLog(const std::tm& timeinfo) {
 
 	logFile.clear();
 	logFile.str("");
-	logFile << "until_" << std::put_time(&timeinfo, "%y%m%d_%Hh_%Mm_%Ss") << ".log";
-	compessionCandidateFile << "until_" << std::put_time(&timeinfo, "%y%m%d_%Hh_%Mm_%Ss") << ".zip";
+	logFile << "until_" << std::put_time(&timeinfo, "%y%m%d_%Hh_%Mm_%Ss") << "_" << recordCount << ".log";
+	compessionCandidateFile << "until_" << std::put_time(&timeinfo, "%y%m%d_%Hh_%Mm_%Ss") << "_" << recordCount << ".zip";
+	recordCount++;
 
 	closeLogFile();
 
-	if (!std::rename(LATEST_LOG_FILENAME.c_str(), logFile.str().c_str())) {
+	if (std::rename(LATEST_LOG_FILENAME.c_str(), logFile.str().c_str())) {
 		std::cerr << "Error: Unable to record " + LATEST_LOG_FILENAME << std::endl;
 	}
 
@@ -61,7 +63,7 @@ void Logger::recordLog(const std::tm& timeinfo) {
 // Logger feature 2: Log compression rules
 /*from .log to .zip */
 void Logger::compressLog() {
-	if (!std::rename(logFile.str().c_str(), compessionCandidateFile.str().c_str())) {
+	if (std::rename(logFile.str().c_str(), compessionCandidateFile.str().c_str())) {
 		std::cerr << "Error: Unable to compress " + logFile.str() << std::endl;
 	}
 	compessionCandidateFile.clear();

--- a/shell/Logger.hpp
+++ b/shell/Logger.hpp
@@ -23,6 +23,7 @@ private:
 	std::ofstream latestLogFile;
 
 	static Logger* instance;
+	int recordCount;
 	bool screenMode = true;
 	std::ostringstream logFile;
 	std::ostringstream compessionCandidateFile;
@@ -52,9 +53,6 @@ public:
 
 	void setScreenMode(bool mode);
 };
-
-// Static member initialization
-//FunctionCallLogger* FunctionCallLogger::instance = nullptr;
 
 // Macro to simplify logging
 #define LOG_FUNCTION_CALL(Message) \

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -10,11 +10,16 @@
 #include "Logger.hpp"
 #include "ShellCmd.cpp"
 
+#define LOGGER_TEST 0
+
 const int MIN_LBA = 0;
 const int VALUE_LENGTH = 10;
 
 const std::string PREFIX_VALUE = "0x";
 const std::string RUNNER_RESULT_FILE_NAME = "testResult.txt";
+
+// Static member initialization
+Logger* Logger::instance = nullptr;
 
 void checkLbaRange(int lba) {
 	if (lba < MIN_LBA || lba > MAX_LBA)
@@ -200,8 +205,9 @@ std::string makeSSDCommand(std::string cmd, std::string arg1, std::string arg2) 
 
 bool testApp1() {
 	const std::string input = "0xABCDEFAB";
-	LOG_FUNCTION_CALL("Full Write: " + input + " + ReadCompare");
 
+	LOG_FUNCTION_CALL("Full Write: " + input + " + ReadCompare");
+	
 	ShellCmdInvoker invoker;
 	std::istringstream iss(input);
 	invoker.setCommand(new ShellFullWriteCommand(iss));
@@ -284,9 +290,6 @@ void doRunner(char* path) {
 	LOG_SCREEN_MODE(true);
 }
 
-// Static member initialization
-Logger* Logger::instance = nullptr;
-
 int main(int argc, char* argv[]) {
 	// for Runner
 	if (argc > 1) {
@@ -294,7 +297,7 @@ int main(int argc, char* argv[]) {
 			return 0;
 
 		doRunner(argv[1]);
-
+		
 		return 0;
 	}
 
@@ -305,6 +308,17 @@ int main(int argc, char* argv[]) {
 		ShellCmdInvoker invoker;
 		std::cout << "Enter a command: "; std::getline(std::cin, command);
 
+#if (LOGGER_TEST == 1)
+		if (command == "loggertest") {
+			for (size_t i = 0; i < 1000; i++)
+			{
+				LOG_FUNCTION_CALL("Full Write: [0x0 ~ 0x5]: + ReadCompare");
+				LOG_FUNCTION_CALL("Full Read: [0x0 ~ 0x5]: + ReadCompare");
+				Sleep(100);
+			}
+			continue;
+		}
+#endif
 		if (!(verifyCommandFormat(command)))
 			continue;
 


### PR DESCRIPTION
…or testing Logger

- Logger에서 zip으로 저장되지않는 case를 확인해 fix  하였습니다.
- 추가로 internal 하게 10KB log를 강제로 발생시켜 logger의 동작을 테스트 하는 부분 추가했고 `LOGGER_TEST` 0 으로 define 하여   normal 한 동작에서는 disable 되게 하였습니다. 

![image](https://github.com/rubber815/BabyStepSSD/assets/11550024/aedafeb4-9cba-4097-b184-1d48b69f7f51)
